### PR TITLE
releng - add python3.11 to release wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs: {}
 env:
-  CIBW_BUILD: "c39-* cp310-*"
+  CIBW_BUILD: "c39-* cp310-* cp311-*"
 jobs:
   Build-Linux:
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,12 @@ setup(
     maintainer="Cloud Custodian Project",
     maintainer_email="cloud-custodian@googlegroups.com",
     license="Apache-2.0",
-    version="0.3.0",
+    version="0.3.1",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: Apache Software License",
     ],
     packages=find_packages(),


### PR DESCRIPTION
change release build config to include python 3.11

closes #62 

