### PR TITLE
Pass allow_downloads config through to parser - fixes #158

### DIFF
--- a/gotfparse/cmd/tfparse/main.go
+++ b/gotfparse/cmd/tfparse/main.go
@@ -26,8 +26,11 @@ func Parse(a *C.char, stopHCL C.int, debug C.int, allowDownloads C.int, num_vars
 	if debug != 0 {
 		options = append(options, converter.WithDebug())
 	}
+
 	if allowDownloads != 0 {
-		options = append(options, converter.WithAllowDownloads())
+		options = append(options, converter.WithAllowDownloads(true))
+	} else {
+		options = append(options, converter.WithAllowDownloads(false))
 	}
 
 	var varFiles []string

--- a/gotfparse/pkg/converter/converter.go
+++ b/gotfparse/pkg/converter/converter.go
@@ -383,8 +383,8 @@ func (t *terraformConverter) SetStopOnHCLError() {
 }
 
 // SetAllowDownloads is a TerraformConverter option that enables downloading modules.
-func (t *terraformConverter) SetAllowDownloads() {
-	t.parserOptions = append(t.parserOptions, parser.OptionWithDownloads(true))
+func (t *terraformConverter) SetAllowDownloads(allowed bool) {
+	t.parserOptions = append(t.parserOptions, parser.OptionWithDownloads(allowed))
 }
 
 // SetTFVarsPaths is a TerraformConverter option that sets a variables file for HCL interpolation.

--- a/gotfparse/pkg/converter/options.go
+++ b/gotfparse/pkg/converter/options.go
@@ -5,7 +5,7 @@ package converter
 type TerraformConverterOptions interface {
 	SetDebug()
 	SetStopOnHCLError()
-	SetAllowDownloads()
+	SetAllowDownloads(allowed bool)
 	SetTFVarsPaths(paths ...string)
 }
 
@@ -26,9 +26,9 @@ func WithStopOnHCLError() TerraformConverterOption {
 }
 
 // WithStopOnHCLError sets the underlying defsec parser to error and stop on HCL parsing errors.
-func WithAllowDownloads() TerraformConverterOption {
+func WithAllowDownloads(allowed bool) TerraformConverterOption {
 	return func(t TerraformConverterOptions) {
-		t.SetAllowDownloads()
+		t.SetAllowDownloads(allowed)
 	}
 }
 


### PR DESCRIPTION
The terraform parsing library defaults to allowing downloads, and tfparse was only passing the `allow_downloads` config value when it was *not* falsey, resulting in downloads always being enabled. This change always passes the `allow_downloads` config, allowing the expected behavior.