### PR TITLE
releng - try release asset upload automation fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,8 @@ jobs:
       contents: write
     if: startsWith(github.ref, 'refs/tags/')
     steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11      
       - name: Fetch Wheels
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110
         with:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     maintainer="Cloud Custodian Project",
     maintainer_email="cloud-custodian@googlegroups.com",
     license="Apache-2.0",
-    version="0.6.4",
+    version="0.6.5",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION


its not clear why but gh release upload was failing with an error
about not having a git checkout.


also noting another issue with the provenance generator, apparently
artifact (upload & download) at v4 are not compatible with v3 which the
generator uses. :/

https://github.com/slsa-framework/slsa-github-generator/issues/3068
