### PR TITLE
Update Golang version to 1.21.5 in ci-setup-golang.sh

### DIFF
--- a/ci-setup-golang.sh
+++ b/ci-setup-golang.sh
@@ -12,7 +12,7 @@ case $OS in
     Linux) OS="linux" ;;
 esac    
 	    
-curl "https://storage.googleapis.com/golang/go1.19.2.${OS}-${ARCH}.tar.gz" --silent --location | tar -xz
+curl "https://storage.googleapis.com/golang/go${GOVER}.${OS}-${ARCH}.tar.gz" --silent --location | tar -xz
 
 export PATH="$(pwd)/go/bin:$PATH"
 


### PR DESCRIPTION
go1.19.2 has few vulnerabilities CVE-2023-24538, CVE-2023-24540, CVE-2023-45285.

Updating the golang version to 1.21.5 to remediate the vulnerabilities.