### PR TITLE
fix: re-evaluate submodules when inputs change

### DIFF
--- a/gotfparse/go.mod
+++ b/gotfparse/go.mod
@@ -67,4 +67,4 @@ require (
 	google.golang.org/protobuf v1.32.0 // indirect
 )
 
-replace github.com/aquasecurity/defsec v0.93.1 => github.com/fwereade/defsec v0.93.2-0.20240320112503-31b908f8c7bf
+replace github.com/aquasecurity/defsec v0.93.1 => github.com/cloud-custodian/defsec v0.93.2-0.20240322122006-69f7f1796542

--- a/gotfparse/go.mod
+++ b/gotfparse/go.mod
@@ -66,3 +66,5 @@ require (
 	google.golang.org/grpc v1.60.1 // indirect
 	google.golang.org/protobuf v1.32.0 // indirect
 )
+
+replace github.com/aquasecurity/defsec v0.93.1 => github.com/fwereade/defsec v0.93.2-0.20240312130557-6f84121175f8

--- a/gotfparse/go.mod
+++ b/gotfparse/go.mod
@@ -67,4 +67,4 @@ require (
 	google.golang.org/protobuf v1.32.0 // indirect
 )
 
-replace github.com/aquasecurity/defsec v0.93.1 => github.com/fwereade/defsec v0.93.2-0.20240312130557-6f84121175f8
+replace github.com/aquasecurity/defsec v0.93.1 => github.com/fwereade/defsec v0.93.2-0.20240320112503-31b908f8c7bf

--- a/gotfparse/go.sum
+++ b/gotfparse/go.sum
@@ -203,8 +203,6 @@ github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4t
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/aquasecurity/defsec v0.93.1 h1:y4XgRknjs2M58XVLANBT1wulO7N6Rz1oyfwNuzID+h4=
-github.com/aquasecurity/defsec v0.93.1/go.mod h1:i80K4WRNbcIWDOQDWnTHkutBwplzw/uZD4laKbhu4sE=
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.49.16 h1:KAQwhLg296hfffRdh+itA9p7Nx/3cXS/qOa3uF9ssig=
 github.com/aws/aws-sdk-go v1.49.16/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
@@ -251,6 +249,8 @@ github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBF
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fwereade/defsec v0.93.2-0.20240312130557-6f84121175f8 h1:1lLXVSev5bh2bi6fppsf/OGiyeuP3ixzUGtBXQtDPS8=
+github.com/fwereade/defsec v0.93.2-0.20240312130557-6f84121175f8/go.mod h1:i80K4WRNbcIWDOQDWnTHkutBwplzw/uZD4laKbhu4sE=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/go-billy/v5 v5.4.0 h1:Vaw7LaSTRJOUric7pe4vnzBSgyuf2KrLsu2Y4ZpQBDE=

--- a/gotfparse/go.sum
+++ b/gotfparse/go.sum
@@ -218,6 +218,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloud-custodian/defsec v0.93.2-0.20240322122006-69f7f1796542 h1:JhRWMiuTUVNh6Gl14u7Ov8we7cjVIezUhr85AbNiBas=
+github.com/cloud-custodian/defsec v0.93.2-0.20240322122006-69f7f1796542/go.mod h1:i80K4WRNbcIWDOQDWnTHkutBwplzw/uZD4laKbhu4sE=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -249,8 +251,6 @@ github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBF
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fwereade/defsec v0.93.2-0.20240320112503-31b908f8c7bf h1:V222LCXSrluan0KfkQFewLncsEOZ31THFBFKLgePohI=
-github.com/fwereade/defsec v0.93.2-0.20240320112503-31b908f8c7bf/go.mod h1:i80K4WRNbcIWDOQDWnTHkutBwplzw/uZD4laKbhu4sE=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/go-billy/v5 v5.4.0 h1:Vaw7LaSTRJOUric7pe4vnzBSgyuf2KrLsu2Y4ZpQBDE=

--- a/gotfparse/go.sum
+++ b/gotfparse/go.sum
@@ -249,8 +249,8 @@ github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBF
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fwereade/defsec v0.93.2-0.20240312130557-6f84121175f8 h1:1lLXVSev5bh2bi6fppsf/OGiyeuP3ixzUGtBXQtDPS8=
-github.com/fwereade/defsec v0.93.2-0.20240312130557-6f84121175f8/go.mod h1:i80K4WRNbcIWDOQDWnTHkutBwplzw/uZD4laKbhu4sE=
+github.com/fwereade/defsec v0.93.2-0.20240320112503-31b908f8c7bf h1:V222LCXSrluan0KfkQFewLncsEOZ31THFBFKLgePohI=
+github.com/fwereade/defsec v0.93.2-0.20240320112503-31b908f8c7bf/go.mod h1:i80K4WRNbcIWDOQDWnTHkutBwplzw/uZD4laKbhu4sE=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/go-billy/v5 v5.4.0 h1:Vaw7LaSTRJOUric7pe4vnzBSgyuf2KrLsu2Y4ZpQBDE=

--- a/tests/terraform/module-in-out/main.tf
+++ b/tests/terraform/module-in-out/main.tf
@@ -1,0 +1,24 @@
+variable "tags" {
+  type = map(any)
+  default = {
+    env = "dev"
+    app = "weather"
+  }
+}
+
+
+module "tags_base" {
+  source    = "./module/tags"
+  tags_base = var.tags
+}
+
+
+locals {
+  default_tags = module.tags_base.tags
+}
+
+
+module "bucket" {
+  source       = "./module/bucket"
+  default_tags = local.default_tags
+}

--- a/tests/terraform/module-in-out/module/bucket/main.tf
+++ b/tests/terraform/module-in-out/module/bucket/main.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_bucket" "bucket_module" {
+  tags = var.default_tags
+}
+
+variable "default_tags" {
+  type = map(string)
+}

--- a/tests/terraform/module-in-out/module/tags/main.tf
+++ b/tests/terraform/module-in-out/module/tags/main.tf
@@ -1,0 +1,22 @@
+
+variable "tags_base" {
+  type    = map(any)
+  default = {}
+}
+
+variable "additional_tags" {
+  type    = map(string)
+  default = {}
+}
+
+
+locals {
+  tags = {
+    "app-id" = "static"
+  }
+
+}
+
+output "tags" {
+  value = merge(local.tags, var.tags_base, var.additional_tags)
+}


### PR DESCRIPTION
Addresses the failing test from #186 

Uses a forked defsec with changes as seen [here](https://github.com/aquasecurity/defsec/compare/v0.93.1...cloud-custodian:defsec:module-re-eval)

To summarize that diff:
* re-evaluates submodules when their inputs change
* fixes object merge bug already handled upstream

There's a small performance hit from re-evaluating the modules but it's reasonably good at _not_ re-evaling when nothing's changed, and I'm pretty confident in the approach. (The hit could probably be reduced by diffing current-submodule-inputs against merged-previous-inputs-and-outputs, instead of against previous-inputs.)

If/when [the upstream bug](https://github.com/aquasecurity/trivy/issues/6274) is fixed, we would still likely be better served updating our dependency to point at https://github.com/aquasecurity/trivy/tree/main/pkg/iac instead of https://github.com/aquasecurity/defsec/tree/v0.93.1/pkg