### PR TITLE
releng: use a single action to create a release and upload assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,18 +127,20 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11      
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Fetch Wheels
         uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85
         with:
           pattern: "*"
           path: dist
           merge-multiple: true
-      - name: Upload Release Assets
-        run: |
-          gh release upload ${{ github.ref_name }} dist/*
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          token: ${{ github.token }}
+          draft: false
+          generateReleaseNotes: true
 
   Upload:
     needs: [Release]


### PR DESCRIPTION
Adapted from the flow used [in poetry-plugin-freeze](https://github.com/cloud-custodian/poetry-plugin-freeze/blob/a525c9f4e21d22519b4c052064c754ae97d9fd88/.github/workflows/release.yml#L33-L40).

It looks like the past few release actions have [failed](https://github.com/cloud-custodian/tfparse/actions/runs/8392232577/job/22986897675) trying to upload assets to a release that didn't yet exist.