### PR TITLE
feat: support tf<0.12 var type expressions

### DIFF
--- a/gotfparse/go.mod
+++ b/gotfparse/go.mod
@@ -74,4 +74,4 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 )
 
-replace github.com/aquasecurity/trivy v0.50.1 => github.com/cloud-custodian/trivy v0.0.0-20240607095740-ad380819f2c5
+replace github.com/aquasecurity/trivy v0.50.1 => github.com/cloud-custodian/trivy v0.0.0-20240607110140-7d824ace9240

--- a/gotfparse/go.mod
+++ b/gotfparse/go.mod
@@ -74,4 +74,4 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 )
 
-replace github.com/aquasecurity/trivy v0.50.1 => github.com/cloud-custodian/trivy v0.0.0-20240424083515-3f81c1ae3a4b
+replace github.com/aquasecurity/trivy v0.50.1 => github.com/cloud-custodian/trivy v0.0.0-20240607095740-ad380819f2c5

--- a/gotfparse/go.sum
+++ b/gotfparse/go.sum
@@ -229,8 +229,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloud-custodian/trivy v0.0.0-20240607095740-ad380819f2c5 h1:9bMLTU27uWZKklgph5Btzu4ZPLCKGs01sH0dabT7i7k=
-github.com/cloud-custodian/trivy v0.0.0-20240607095740-ad380819f2c5/go.mod h1:J1fAS5qlA63Amg4RP5fF8QsF67xvZC5RPZORsibbQQs=
+github.com/cloud-custodian/trivy v0.0.0-20240607110140-7d824ace9240 h1:inb+4gL5NdxD8HAlpz77Owce4YzgWPSDXfh09zctmP8=
+github.com/cloud-custodian/trivy v0.0.0-20240607110140-7d824ace9240/go.mod h1:J1fAS5qlA63Amg4RP5fF8QsF67xvZC5RPZORsibbQQs=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/gotfparse/go.sum
+++ b/gotfparse/go.sum
@@ -229,8 +229,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloud-custodian/trivy v0.0.0-20240424083515-3f81c1ae3a4b h1:8OnMK004B5bmzH010iBsMMr9mgTBLq5xj01M1O6MmRI=
-github.com/cloud-custodian/trivy v0.0.0-20240424083515-3f81c1ae3a4b/go.mod h1:J1fAS5qlA63Amg4RP5fF8QsF67xvZC5RPZORsibbQQs=
+github.com/cloud-custodian/trivy v0.0.0-20240607095740-ad380819f2c5 h1:9bMLTU27uWZKklgph5Btzu4ZPLCKGs01sH0dabT7i7k=
+github.com/cloud-custodian/trivy v0.0.0-20240607095740-ad380819f2c5/go.mod h1:J1fAS5qlA63Amg4RP5fF8QsF67xvZC5RPZORsibbQQs=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/tests/terraform/vars-bad-types/main.tf
+++ b/tests/terraform/vars-bad-types/main.tf
@@ -1,0 +1,25 @@
+variable "empty_block" {
+    // nothing here
+}
+
+output "empty_block" {
+    value = var.empty_block
+}
+
+
+variable "default_only" {
+    default = "huh"
+}
+
+output "default_only" {
+    value = var.default_only
+}
+
+
+variable "quoted_type" {
+    type = "string"
+}
+
+output "quoted_type" {
+    value = var.quoted_type
+}

--- a/tests/terraform/vars-bad-types/numbers.tfvars
+++ b/tests/terraform/vars-bad-types/numbers.tfvars
@@ -1,0 +1,3 @@
+empty_block = 123
+default_only = 456
+quoted_type = 789

--- a/tests/terraform/vars-bad-types/strings.tfvars
+++ b/tests/terraform/vars-bad-types/strings.tfvars
@@ -1,0 +1,3 @@
+empty_block = "one"
+default_only = "two"
+quoted_type = "three"

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -76,6 +76,9 @@ def test_multiple_var_files(tmp_path):
 
 
 def test_vars_bad_types(tmp_path):
+    # NOTE that the "quoted_type" test case is to allow rudimentary support for TF
+    # versions older than 0.11, which are still sometimes seen in the wild. It's
+    # not valid in any TF that's less than 5 years old.
     mod_path = init_module("vars-bad-types", tmp_path, run_init=False)
     assert get_outputs(load_from_path(mod_path)) == {
         "empty_block": None,

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -77,7 +77,7 @@ def test_multiple_var_files(tmp_path):
 
 def test_vars_bad_types(tmp_path):
     # NOTE that the "quoted_type" test case is to allow rudimentary support for TF
-    # versions older than 0.11, which are still sometimes seen in the wild. It's
+    # versions older than 0.12, which are still sometimes seen in the wild. It's
     # not valid in any TF that's less than 5 years old.
     mod_path = init_module("vars-bad-types", tmp_path, run_init=False)
     assert get_outputs(load_from_path(mod_path)) == {

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -75,6 +75,29 @@ def test_multiple_var_files(tmp_path):
     assert item["name"] == "my-app-logs"
 
 
+def test_vars_bad_types(tmp_path):
+    mod_path = init_module("vars-bad-types", tmp_path, run_init=False)
+    assert get_outputs(load_from_path(mod_path)) == {
+        "empty_block": None,
+        "default_only": "huh",
+        "quoted_type": None,
+    }
+    assert get_outputs(load_from_path(mod_path, vars_paths=["numbers.tfvars"])) == {
+        "empty_block": 123,
+        "default_only": 456,  # default value doesn't imply type
+        "quoted_type": "789",  # quoted type is handled, value is coerced
+    }
+    assert get_outputs(load_from_path(mod_path, vars_paths=["strings.tfvars"])) == {
+        "empty_block": "one",
+        "default_only": "two",
+        "quoted_type": "three",
+    }
+
+
+def get_outputs(parsed):
+    return {block["__tfmeta"]["label"]: block["value"] for block in parsed["output"]}
+
+
 def test_parse_vpc_module(tmp_path):
     mod_path = init_module("vpc_module", tmp_path, run_init=False)
     parsed = load_from_path(mod_path, allow_downloads=True)


### PR DESCRIPTION
Points at commit from https://github.com/cloud-custodian/trivy/pull/2 – the specific _changed behaviour_ is the quoted var type, the other tests are to make behaviour around missing types clear.