### PR TITLE
releng - release 0.6.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     maintainer="Cloud Custodian Project",
     maintainer_email="cloud-custodian@googlegroups.com",
     license="Apache-2.0",
-    version="0.6.10",
+    version="0.6.11",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This brings in updates/fixes from upstream, notably https://github.com/aquasecurity/trivy/pull/6411 which appears to address #211 as a side effect thanks to some extra error handling.

Closes #211 