### PR TITLE
fix: correctly show variable type

### DIFF
--- a/gotfparse/pkg/converter/converter.go
+++ b/gotfparse/pkg/converter/converter.go
@@ -137,7 +137,15 @@ func (t *terraformConverter) buildBlock(b *terraform.Block) map[string]interface
 	}
 
 	for _, a := range b.GetAttributes() {
-		obj[a.Name()] = t.getAttributeValue(a, b)
+		attrName := a.Name()
+		if b.Type() == "variable" && attrName == "type" {
+			// for variable type, the plain value is nil (unless the type has
+			// been provided in quotes), look at the variable type instead
+			var_type, _, _ := a.DecodeVarType()
+			obj[attrName] = var_type.FriendlyName()
+		} else {
+			obj[attrName] = t.getAttributeValue(a, b)
+		}
 	}
 
 	id := b.ID()

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -413,7 +413,7 @@ def test_parse_variables(tmp_path):
                     "path": "variable.no_default",
                 },
                 "id": ANY,
-                "type": None,
+                "type": "string",
             },
         ],
     }


### PR DESCRIPTION
Populate the `"type"` field for variables (which currently shows as null).

The type is obtained from the "friendly name" for the CTY var (e.g. `"string"`, `"map of string"`, `"list of string"`).