### PR TITLE
chore: upgrade pypa/cibuildwheel to v2.21.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           platforms: arm64
       - name: Build wheels
-        uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce
+        uses: pypa/cibuildwheel@7940a4c0e76eb2030e473a5f864f291f63ee879b
         env:
           CIBW_ENVIRONMENT: PATH=$(pwd)/go/bin:$PATH
           CIBW_BEFORE_ALL: sh ci-setup-golang.sh
@@ -50,7 +50,7 @@ jobs:
           cache: true
           cache-dependency-path: "gotfparse/go.sum"
       - name: Build wheels
-        uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce
+        uses: pypa/cibuildwheel@7940a4c0e76eb2030e473a5f864f291f63ee879b
         env:
           CGO_ENABLED: 1
           CIBW_ARCHS: AMD64


### PR DESCRIPTION
The python 3.13 wheel publishing [didn't work](https://github.com/cloud-custodian/tfparse/actions/runs/11840022746/job/32992870495#step:4:462), seemingly because the wheel builder didn't have python 3.13 support yet. This updates the pinned hash to the latest release ([v2.21.3](https://github.com/pypa/cibuildwheel/commit/7940a4c0e76eb2030e473a5f864f291f63ee879b)) which is documented as adding 3.13.0 support.