### PR TITLE
fix: distinguish missing attributes vs. unresolved values

### DIFF
--- a/tests/terraform/apply-time-vals/main.tf
+++ b/tests/terraform/apply-time-vals/main.tf
@@ -46,3 +46,15 @@ resource "aws_db_parameter_group" "untagged" {
   name   = "untagged"
   family = "postgres16"
 }
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "attribute_with_direct_reference" {
+    permissions_boundary = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_iam_role" "attribute_with_interpolated_reference" {
+    permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryPolicy"
+}
+
+resource "aws_iam_role" "attribute_not_present" {}

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -628,3 +628,15 @@ def test_apply_time_vals(tmp_path):
     # Test untagged resource
     untagged = parsed["aws_db_parameter_group"][0]
     assert "tags" not in untagged
+
+    # Test attribute handling for different scenarios
+    role_attributes = {
+        role["__tfmeta"]["path"]: role.get("permissions_boundary")
+        for role in parsed["aws_iam_role"]
+    }
+    assert role_attributes["aws_iam_role.attribute_not_present"] is None
+    assert role_attributes["aws_iam_role.attribute_with_direct_reference"] == {}
+    assert (
+        role_attributes["aws_iam_role.attribute_with_interpolated_reference"]
+        == "arn:aws:iam:::policy/BoundaryPolicy"
+    )

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -82,9 +82,9 @@ def test_vars_bad_types(tmp_path):
     # not valid in any TF that's less than 5 years old.
     mod_path = init_module("vars-bad-types", tmp_path, run_init=False)
     assert get_outputs(load_from_path(mod_path)) == {
-        "empty_block": None,
+        "empty_block": {},
         "default_only": "huh",
-        "quoted_type": None,
+        "quoted_type": {},
     }
     assert get_outputs(load_from_path(mod_path, vars_paths=["numbers.tfvars"])) == {
         "empty_block": 123,
@@ -267,7 +267,7 @@ def test_moved_blocks(tmp_path):
     parsed = load_from_path(mod_path)
 
     (item,) = parsed["moved"]
-    assert item["from"] is None
+    assert item["from"] == {}
     assert len(item["to"]) == 2
 
 
@@ -610,7 +610,7 @@ def test_ec2_tags(tmp_path):
 
     # Test untagged instance
     untagged = parsed["aws_instance"][2]
-    assert untagged["tags"] is None
+    assert untagged["tags"] == {}
 
 
 def test_apply_time_vals(tmp_path):


### PR DESCRIPTION
In tfparse 0.6.15 we started trying to render attribute values where possible. As a side effect, that made it more difficult to tell the difference between an attribute that isn't specified as opposed to one that is specified but not statically resolvable. See https://github.com/cloud-custodian/cloud-custodian/issues/10119 for a concrete example from c7n-left.

For a more tfparse-focused view, we can look at this sample template:

```hcl
data "aws_caller_identity" "current" {}

resource "aws_iam_role" "attribute_with_direct_reference" {
    permissions_boundary = data.aws_caller_identity.current.account_id
}

resource "aws_iam_role" "attribute_with_interpolated_reference" {
    permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryPolicy"
}

resource "aws_iam_role" "attribute_not_present" {}
```

A `c7n-left dump` of that template using `tfparse==0.6.14` produces something like this:

<details>

<summary>tfparse 0.6.14 dump</summary>

```json
{
  "input_vars": {},
  "graph": {
    "aws_caller_identity": [
      {
        "__tfmeta": {
          "filename": "main.tf",
          "label": "aws_caller_identity",
          "line_end": 1,
          "line_start": 1,
          "path": "data.aws_caller_identity.current",
          "type": "data"
        },
        "id": "545de037-362e-4f37-8191-b6b3759237e7"
      }
    ],
    "aws_iam_role": [
      {
        "__tfmeta": {
          "filename": "main.tf",
          "label": "aws_iam_role",
          "line_end": 11,
          "line_start": 11,
          "path": "aws_iam_role.attribute_not_present",
          "type": "resource"
        },
        "id": "b0b4c9e2-773c-4fa7-8721-1a7244475445"
      },
      {
        "__tfmeta": {
          "filename": "main.tf",
          "label": "aws_iam_role",
          "line_end": 5,
          "line_start": 3,
          "path": "aws_iam_role.attribute_with_direct_reference",
          "type": "resource"
        },
        "id": "87563f2a-7eb8-43f0-bae8-8d599b8123c1",
        "permissions_boundary": {
          "__attribute__": "data.aws_caller_identity.current.account_id",
          "__name__": "current",
          "__ref__": "545de037-362e-4f37-8191-b6b3759237e7",
          "__type__": "aws_caller_identity"
        }
      },
      {
        "__tfmeta": {
          "filename": "main.tf",
          "label": "aws_iam_role",
          "line_end": 9,
          "line_start": 7,
          "path": "aws_iam_role.attribute_with_interpolated_reference",
          "type": "resource"
        },
        "id": "c10aed11-cd73-4586-9d98-80e747425679",
        "permissions_boundary": {
          "__attribute__": "data.aws_caller_identity.current.account_id",
          "__name__": "current",
          "__ref__": "545de037-362e-4f37-8191-b6b3759237e7",
          "__type__": "aws_caller_identity"
        }
      }
    ]
  }
}
```

</details>

While the same dump using `tfparse==0.6.15` produces:

<details>

<summary>tfparse 0.6.15 dump</summary>

```json
{
  "input_vars": {},
  "graph": {
    "aws_caller_identity": [
      {
        "__tfmeta": {
          "filename": "main.tf",
          "label": "aws_caller_identity",
          "line_end": 1,
          "line_start": 1,
          "path": "data.aws_caller_identity.current",
          "type": "data"
        },
        "id": "dc4d1cbf-ad75-41e3-b7fe-bdab5f7c3e89"
      }
    ],
    "aws_iam_role": [
      {
        "__tfmeta": {
          "filename": "main.tf",
          "label": "aws_iam_role",
          "line_end": 11,
          "line_start": 11,
          "path": "aws_iam_role.attribute_not_present",
          "type": "resource"
        },
        "id": "2263a037-c1cc-42bc-8c2d-a40b2af8f900"
      },
      {
        "__tfmeta": {
          "filename": "main.tf",
          "label": "aws_iam_role",
          "line_end": 5,
          "line_start": 3,
          "path": "aws_iam_role.attribute_with_direct_reference",
          "type": "resource"
        },
        "id": "911b7fb9-7b77-40d9-8cae-b05c2436afe1",
        "permissions_boundary": null
      },
      {
        "__tfmeta": {
          "filename": "main.tf",
          "label": "aws_iam_role",
          "line_end": 9,
          "line_start": 7,
          "path": "aws_iam_role.attribute_with_interpolated_reference",
          "type": "resource"
        },
        "id": "3993e975-418b-433f-85bb-4bd3d486e4ec",
        "permissions_boundary": null
      }
    ]
  }
}
```

</details>

This PR uses an empty object to represent unresolvable direct references, and renders only the literal portions of template strings.

There are other ways to tackle this (more explicit sentinel values for those unresolved references, perhaps) but this approach tries to mimic the logic of https://github.com/cloud-custodian/tfparse/pull/238 and address the core problem from https://github.com/cloud-custodian/cloud-custodian/issues/10119.