### PR TITLE
provide more information for unresolved values

### DIFF
--- a/tests/terraform/apply-time-vals/main.tf
+++ b/tests/terraform/apply-time-vals/main.tf
@@ -46,3 +46,39 @@ resource "aws_db_parameter_group" "untagged" {
   name   = "untagged"
   family = "postgres16"
 }
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "attribute_with_direct_reference" {
+  permissions_boundary = data.aws_caller_identity.current.account_id
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "attribute_with_interpolated_reference" {
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryPolicy"
+    assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "attribute_not_present" {}

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -82,9 +82,9 @@ def test_vars_bad_types(tmp_path):
     # not valid in any TF that's less than 5 years old.
     mod_path = init_module("vars-bad-types", tmp_path, run_init=False)
     assert get_outputs(load_from_path(mod_path)) == {
-        "empty_block": {'__attribute__': 'var.empty_block', '__name__': 'empty_block'},
+        "empty_block": {"__attribute__": "var.empty_block", "__name__": "empty_block"},
         "default_only": "huh",
-        "quoted_type": {'__attribute__': 'var.quoted_type', '__name__': 'quoted_type'},
+        "quoted_type": {"__attribute__": "var.quoted_type", "__name__": "quoted_type"},
     }
     assert get_outputs(load_from_path(mod_path, vars_paths=["numbers.tfvars"])) == {
         "empty_block": 123,


### PR DESCRIPTION
When referencing variables that haven't been defined or data sources that aren't available, instead of just putting in `None` lets return what value we didn't resolve.

This also leaves strings with unresolved values uninterpolated so we know exactly what they were trying to do.