### PR TITLE
fix: skip dynamic blocks that iterate over an unknown

### DIFF
--- a/gotfparse/pkg/converter/converter.go
+++ b/gotfparse/pkg/converter/converter.go
@@ -576,7 +576,7 @@ func getChildBlocks(b *terraform.Block) []*terraform.Block {
 		attr := b.GetAttribute("for_each")
 
 		value := attr.Value()
-		if value.IsNull() {
+		if value.IsNull() || !value.IsKnown() {
 			return 0
 		}
 

--- a/tests/terraform/dynamic-stuff/main.tf
+++ b/tests/terraform/dynamic-stuff/main.tf
@@ -38,4 +38,16 @@ resource "some_resource" "this" {
   }
 
   prop3 = "end"
+
+  dynamic "unknown_loop" {
+    for_each = var.unknown
+
+    content {
+      other = each.value
+    }
+  }
+}
+
+variable "unknown" {
+  type = set(string)
 }

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -280,11 +280,25 @@ def test_parse_dynamic_content(tmp_path):
     # mod_path = init_module("dynamic-stuff", tmp_path)
     parsed = load_from_path(mod_path, debug=True)
 
+    vars = [
+        {
+            "__tfmeta": {
+                "filename": "main.tf",
+                "label": "unknown",
+                "line_end": 53,
+                "line_start": 51,
+                "path": "variable.unknown",
+            },
+            "id": ANY,
+            "type": "set of string",
+        }
+    ]
+
     resource = {
         "__tfmeta": {
             "filename": "main.tf",
             "label": "some_resource",
-            "line_end": 41,
+            "line_end": 49,
             "line_start": 1,
             "path": ANY,
             "type": "resource",
@@ -363,6 +377,7 @@ def test_parse_dynamic_content(tmp_path):
             resource,
             resource,
         ],
+        "variable": vars,
     }
 
 


### PR DESCRIPTION
If the value of a dynamic block's `for_each` is unknown at parse time, treat it the same as a null value.

Without the changes in `converter.go`, the additions to `test_parse_dynamic_content()` cause that test to crash and reproduce the error reported in #249.

Closes #249