### PR TITLE
fix: preserve parent module context in references

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,16 +68,17 @@ jobs:
 
       - name: Install uv
         id: setup-uv-lint
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # ratchet:astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
+          activate-environment: true
 
       - name: Install c7n-left
         shell: bash
         working-directory: custodian/tools/c7n_left
         run: |
-          uv sync --frozen --inexact
+          uv sync --frozen --inexact --active
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
+env:
+  UV_VERSION: "0.7.12"
+  DEFAULT_PY_VERSION: "3.12"
+
 jobs:
   Lint:
     runs-on: ubuntu-latest
@@ -20,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: "3.13"
+          python-version: ${{ env.DEFAULT_PY_VERSION }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -48,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: 3.12
+          python-version: ${{ env.DEFAULT_PY_VERSION }}
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
@@ -62,36 +66,31 @@ jobs:
           cache: true
           cache-dependency-path: "gotfparse/go.sum"
 
-      - name: Set up Poetry
-        shell: bash
-        run: "pipx install poetry==1.5.1"
-
-      - name: Setup virtualenv
-        shell: bash
-        run: "python -m venv .venv"
-
-      - name: Activate virtualenv
-        run: |
-          echo "$PWD/.venv/bin" >> $GITHUB_PATH
-          echo "VIRTUAL_ENV=$PWD/.venv" >> $GITHUB_ENV
+      - name: Install uv
+        id: setup-uv-lint
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # ratchet:astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
 
       - name: Install c7n-left
         shell: bash
         working-directory: custodian/tools/c7n_left
-        run: poetry install
+        run: |
+          uv sync --frozen --inexact
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          uv pip install -r requirements-dev.txt
 
       - name: Install package
         run: |
-          pip install -e .
+          uv pip install -e .
 
       - name: Run c7n-left tests
         working-directory: custodian
-        run: pytest tools/c7n_left/tests
+        run: |
+          uv run pytest tools/c7n_left/tests
 
   Tests:
     needs: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Run c7n-left tests
         working-directory: custodian
         run: |
-          uv run pytest tools/c7n_left/tests
+          uv run --active pytest tools/c7n_left/tests
 
   Tests:
     needs: Lint

--- a/gotfparse/pkg/converter/converter.go
+++ b/gotfparse/pkg/converter/converter.go
@@ -102,6 +102,22 @@ func newReferenceTracker() referenceTracker {
 	}
 }
 
+// Get a reference's fully qualified path in the form of `parent.type.name`,
+// to help preserve reference tracking for resources inside modules.
+//
+// The upstream implementation of reference.HumanReadable() was the closest
+// way to get a fully qualified path using only public members. We implement
+// a tweaked version of that function here, rather than performing a local
+// replace on the HumanReadable() value. This is _probably_ the more stable
+// option, but it's still a hack.
+func getPath(r *terraform.Reference) string {
+	parent := getPrivateValue(r, "parent").(string)
+	if parent == "" {
+		return r.String()
+	}
+	return fmt.Sprintf("%s.%s", parent, r.String())
+}
+
 type terraformConverter struct {
 	filePath         string
 	modules          terraform.Modules
@@ -235,12 +251,7 @@ func (t *terraformConverter) buildBlock(b *terraform.Block) map[string]interface
 		}
 
 		for _, ref := range a.AllReferences() {
-			// We don't have access to ref.parent here to capture parent module
-			// path info. However, for references inside modules HumanReadable()
-			// joins the module and resource paths together with a colon. That's
-			// one replace away from matching the full resource path that
-			// ProcessBlocksReferences() looks for.
-			allRefs.Add(strings.Replace(ref.HumanReadable(), ":", ".", -1))
+			allRefs.Add(getPath(ref))
 		}
 	}
 

--- a/gotfparse/pkg/converter/converter.go
+++ b/gotfparse/pkg/converter/converter.go
@@ -235,7 +235,12 @@ func (t *terraformConverter) buildBlock(b *terraform.Block) map[string]interface
 		}
 
 		for _, ref := range a.AllReferences() {
-			allRefs.Add(ref.String())
+			// We don't have access to ref.parent here to capture parent module
+			// path info. However, for references inside modules HumanReadable()
+			// joins the module and resource paths together with a colon. That's
+			// one replace away from matching the full resource path that
+			// ProcessBlocksReferences() looks for.
+			allRefs.Add(strings.Replace(ref.HumanReadable(), ":", ".", -1))
 		}
 	}
 

--- a/tests/terraform/module-references/main.tf
+++ b/tests/terraform/module-references/main.tf
@@ -1,0 +1,17 @@
+module "bucket" {
+  source      = "./modules/nonpublic_bucket"
+  bucket_name = "module-bucket"
+}
+
+resource "aws_s3_bucket" "outside_module" {
+  bucket = "non-module-bucket"
+}
+
+resource "aws_s3_bucket_public_access_block" "outside_module" {
+  bucket = aws_s3_bucket.outside_module.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/tests/terraform/module-references/modules/nonpublic_bucket/main.tf
+++ b/tests/terraform/module-references/modules/nonpublic_bucket/main.tf
@@ -1,0 +1,16 @@
+resource "aws_s3_bucket" "inside_module" {
+  bucket = var.bucket_name
+}
+
+variable "bucket_name" {
+  type = string
+}
+
+resource "aws_s3_bucket_public_access_block" "inside_module" {
+  bucket = aws_s3_bucket.inside_module.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -475,6 +475,24 @@ def test_references(tmp_path):
     ]
 
 
+def test_module_references(tmp_path):
+    mod_path = init_module("module-references", tmp_path)
+    parsed = load_from_path(mod_path)
+
+    buckets = parsed["aws_s3_bucket"]
+    public_access_blocks = parsed["aws_s3_bucket_public_access_block"]
+
+    for bucket, public_access_block in zip(buckets, public_access_blocks):
+        assert bucket["id"] == public_access_block["__tfmeta"]["references"][0]["id"]
+        assert (
+            bucket["__tfmeta"]["label"]
+            == public_access_block["__tfmeta"]["references"][0]["label"]
+        )
+        assert bucket["__tfmeta"]["path"].endswith(
+            public_access_block["__tfmeta"]["references"][0]["name"]
+        )
+
+
 def test_modules_located_above_root(tmp_path):
     mod_path = init_module("local-module-above-root", tmp_path)
     parsed = load_from_path(os.path.join(mod_path, "root"))


### PR DESCRIPTION
Include the parent module path when identifying references, otherwise we'll skip those references when [building references metadata blocks](https://github.com/ajkerrigan/tfparse/blob/013fc62d44c462d666633b019c234aae5e016199/gotfparse/pkg/converter/converter.go#L83).

Drive-by: Make enough changes to the CI configuration so that c7n-left tests run, following the upstream [switch to uv](https://github.com/cloud-custodian/cloud-custodian/pull/10140)