### PR TITLE
fix: also check if value is wholly known to successfully run in not wholly known for_each blocks

### DIFF
--- a/gotfparse/pkg/converter/converter.go
+++ b/gotfparse/pkg/converter/converter.go
@@ -284,7 +284,7 @@ func (t *terraformConverter) getAttributeValue(a *terraform.Attribute) any {
 
 	// Only attempt to handle functions manually if the value is null or not known
 	// This ensures we don't interfere with functions that have been successfully resolved
-	if val.IsNull() || !val.IsKnown() {
+	if val.IsNull() || !val.IsKnown() || !val.IsWhollyKnown() {
 		// Check if it's a function call that might have failed due to unresolvable variables
 		hclAttr := getPrivateValue(a, "hclAttribute").(*hcl.Attribute)
 

--- a/tests/terraform/not-wholly-known-for_each/main.tf
+++ b/tests/terraform/not-wholly-known-for_each/main.tf
@@ -1,0 +1,8 @@
+locals {
+  current_month = formatdate("M", plantimestamp())
+  last_month    = local.current_month == "1" ? "12" : tostring(tonumber(local.current_month) - 1)
+}
+
+resource "terraform_data" "dummy" {
+      for_each = toset([local.last_month, local.current_month])
+}

--- a/tests/terraform/wholly-known-for_each/main.tf
+++ b/tests/terraform/wholly-known-for_each/main.tf
@@ -1,0 +1,8 @@
+locals {
+  current_month = 6
+  last_month    = 5
+}
+
+resource "terraform_data" "dummy" {
+      for_each = toset([local.last_month, local.current_month])
+}

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -688,3 +688,19 @@ def test_handle_sensitive_value(tmp_path):
     parsed = load_from_path(mod_path)
     assert parsed["locals"][0]["sensitive-thing"] == "(sensitive value)"
     assert parsed["locals"][0]["non-sensitive-thing"] == "NON-SENSITIVE-THING"
+
+
+def test_wholly_known_foreach(tmp_path):
+    mod_path = init_module("wholly-known-for_each", tmp_path, run_init=False)
+    parsed = load_from_path(mod_path)
+    assert parsed["locals"][0]["current_month"] ==6
+    assert parsed["locals"][0]["last_month"] == 5
+    assert parsed["terraform_data"][0]["for_each"] == [5, 6]
+
+
+def test_not_wholly_known_foreach(tmp_path):
+    mod_path = init_module("not-wholly-known-for_each", tmp_path, run_init=False)
+    parsed = load_from_path(mod_path)
+    assert parsed["locals"][0]["current_month"] is None
+    assert parsed["locals"][0]["last_month"] is None
+    assert parsed["terraform_data"][0]["for_each"] is None


### PR DESCRIPTION
Expands on the change https://github.com/cloud-custodian/tfparse/pull/252 to also check if a value is wholly known. This appears to cause unknown value panics if a `for_each` is not wholly known (see https://github.com/cloud-custodian/tfparse/issues/258).