### PR TITLE
fix: unresolved JSON strings aren't valid JSON

### DIFF
--- a/tests/terraform/module-output-json-string/main.tf
+++ b/tests/terraform/module-output-json-string/main.tf
@@ -1,0 +1,36 @@
+# Variables without defaults - makes them unresolvable at static analysis time
+variable "root_task_name" {
+  type = string
+  # NO DEFAULT - unresolvable
+}
+
+variable "root_image" {
+  type = string
+  # NO DEFAULT - unresolvable
+}
+
+# Direct module usage - this works fine
+module "container_direct" {
+  source = "./module"
+  name   = "direct-container"
+  image  = "nginx:latest"
+}
+
+resource "aws_ecs_task_definition" "direct" {
+  family                   = "direct-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+
+  # Direct module reference - this should work
+  container_definitions = module.container_direct.json_encoded_list
+}
+
+# Nested module usage - this reproduces the issue
+# Pass unresolvable variables to the wrapper module
+module "task_wrapper" {
+  source    = "./modules/task_wrapper"
+  task_name = var.root_task_name  # Unknown!
+  image     = var.root_image      # Unknown!
+}

--- a/tests/terraform/module-output-json-string/minimal_module/main.tf
+++ b/tests/terraform/module-output-json-string/minimal_module/main.tf
@@ -1,0 +1,37 @@
+variable "container_name" {
+  type = string
+}
+
+variable "map_environment" {
+  type    = map(string)
+  default = null
+}
+
+locals {
+  # This pattern triggers UnknownVal: for loop inside ternary
+  final_environment_vars = var.map_environment != null ? [
+    for k, v in var.map_environment : {
+      name  = k
+      value = v
+    }
+  ] : null
+
+  container_definition = {
+    name        = var.container_name
+    environment = local.final_environment_vars
+  }
+
+  container_definition_without_null = {
+    for k, v in local.container_definition :
+    k => v
+    if v != null
+  }
+
+  final_container_definition = merge(local.container_definition_without_null, {})
+
+  json_map = jsonencode(local.final_container_definition)
+}
+
+output "json_map_encoded_list" {
+  value = "[${local.json_map}]"
+}

--- a/tests/terraform/module-output-json-string/module/main.tf
+++ b/tests/terraform/module-output-json-string/module/main.tf
@@ -1,0 +1,36 @@
+variable "name" {
+  type        = string
+  description = "Container name"
+}
+
+variable "image" {
+  type        = string
+  description = "Container image"
+}
+
+locals {
+  container_definition = {
+    name      = var.name
+    image     = var.image
+    essential = true
+    portMappings = [
+      {
+        containerPort = 80
+        protocol      = "tcp"
+      }
+    ]
+  }
+
+  # This simulates what simple modules do - direct jsonencode
+  json_map = jsonencode(local.container_definition)
+}
+
+output "json_encoded_list" {
+  description = "JSON string encoded list of container definitions"
+  value       = "[${local.json_map}]"
+}
+
+output "json_map_object" {
+  description = "Container definition as an object"
+  value       = local.container_definition
+}

--- a/tests/terraform/module-output-json-string/modules/task_wrapper/main.tf
+++ b/tests/terraform/module-output-json-string/modules/task_wrapper/main.tf
@@ -1,0 +1,37 @@
+variable "task_name" {
+  type = string
+  # NO DEFAULT - makes it unresolvable at static analysis time
+}
+
+variable "image" {
+  type = string
+  # NO DEFAULT - makes it unresolvable at static analysis time
+}
+
+variable "environment_vars" {
+  type    = map(string)
+  default = {}
+  # Has a default, but when overridden, makes things unresolvable
+}
+
+# Nested module - testing minimal complexity to trigger UnknownVal
+module "container" {
+  source          = "../../minimal_module"
+  container_name  = var.task_name  # Unknown!
+  container_image = var.image      # Unknown!
+}
+
+resource "aws_ecs_task_definition" "wrapped_task" {
+  family                   = var.task_name
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+
+  # This references a nested module output (cloudposse uses json_map_encoded_list)
+  container_definitions = module.container.json_map_encoded_list
+}
+
+output "task_arn" {
+  value = aws_ecs_task_definition.wrapped_task.arn
+}


### PR DESCRIPTION
When we have a JSON string (like container definitions) if it is unresolved we are inserting a reference string in there to what was unresolved but its not valid JSON so if anyone uses `fromjson()` on it it will fail.

This detects JSON strings and formats it properly while maintaining the reference.