### PR TITLE
fix: update go download url for linux

### DIFF
--- a/ci-setup-golang.sh
+++ b/ci-setup-golang.sh
@@ -12,7 +12,7 @@ case $OS in
     Linux) OS="linux" ;;
 esac    
 	    
-curl "https://storage.googleapis.com/golang/go${GOVER}.${OS}-${ARCH}.tar.gz" --silent --location | tar -xz
+curl "https://go.dev/dl/go${GOVER}.${OS}-${ARCH}.tar.gz" --silent --location | tar -xz
 
 export PATH="$(pwd)/go/bin:$PATH"
 


### PR DESCRIPTION
Our Linux builds use a custom script that fetches a Go binary from a Google storage bucket. The URL pattern in release announcement uses go.dev/dl instead, and the availability of binaries through storage bucket links seems inconsistent recently:

https://groups.google.com/g/golang-nuts/c/xL-B4XggX04?pli=1

So let's do what Google says we should anyway.

_To be honest I'm not sure why we use a custom shell script for Linux and dedicated setup actions for other platforms, that may be worth digging into separately..._