### PR TITLE
fix: resolve for_each and data references

### DIFF
--- a/gotfparse/go.mod
+++ b/gotfparse/go.mod
@@ -116,4 +116,4 @@ require (
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 )
 
-replace github.com/aquasecurity/trivy => github.com/cloud-custodian/trivy v0.0.0-20260821210141-935427cb1907
+replace github.com/aquasecurity/trivy => github.com/cloud-custodian/trivy v0.0.0-20260910170940-2360a66b9fee

--- a/gotfparse/go.sum
+++ b/gotfparse/go.sum
@@ -100,8 +100,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cloud-custodian/trivy v0.0.0-20260821210141-935427cb1907 h1:pI6NnSO5+O3fRlRHYnbn70beSwxQzR/bIp/Soo53fzo=
-github.com/cloud-custodian/trivy v0.0.0-20260821210141-935427cb1907/go.mod h1:Wf+eykRx2CxQsmo0e0gy8t7byAVbj6FpevuipHcodCc=
+github.com/cloud-custodian/trivy v0.0.0-20260910170940-2360a66b9fee h1:538DMQT4rhwukGVP3aNMtzSa0uXJ8aAHUxT4JOP5N9c=
+github.com/cloud-custodian/trivy v0.0.0-20260910170940-2360a66b9fee/go.mod h1:Wf+eykRx2CxQsmo0e0gy8t7byAVbj6FpevuipHcodCc=
 github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=
 github.com/cloudflare/circl v1.6.4/go.mod h1:YxarevkLlbaHuWsxG6vmYNWBEsSp4pnp7j+4VljMavY=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=

--- a/gotfparse/pkg/converter/converter.go
+++ b/gotfparse/pkg/converter/converter.go
@@ -112,11 +112,29 @@ func newReferenceTracker() referenceTracker {
 // replace on the HumanReadable() value. This is _probably_ the more stable
 // option, but it's still a hack.
 func getPath(r *terraform.Reference) string {
+	base := getBlockRef(r)
 	parent := getPrivateValue(r, "parent").(string)
 	if parent == "" {
-		return r.String()
+		return base
 	}
-	return fmt.Sprintf("%s.%s", parent, r.String())
+	return fmt.Sprintf("%s.%s", parent, base)
+}
+
+// Get the path of the block a reference points at, dropping any attribute
+// names trailing it.
+//
+// Reference.String() keeps those names, so `data.aws_ami.ubuntu.id` renders in
+// full and never matches the path of the block it refers to,
+// `data.aws_ami.ubuntu`. Only resource references are unaffected, because the
+// block type is left out of their path, which shifts everything up by one and
+// leaves the common `type.name.attr` form with nothing trailing to drop.
+func getBlockRef(r *terraform.Reference) string {
+	ref := r.String()
+	remainder, ok := getPrivateValue(r, "remainder").([]string)
+	if !ok || len(remainder) == 0 {
+		return ref
+	}
+	return strings.TrimSuffix(ref, "."+strings.Join(remainder, "."))
 }
 
 type terraformConverter struct {

--- a/tests/terraform/data-references/main.tf
+++ b/tests/terraform/data-references/main.tf
@@ -1,0 +1,13 @@
+data "aws_rds_reserved_instance_offering" "example" {
+  db_instance_class = "db.m7g.large"
+}
+
+resource "aws_rds_reserved_instance" "example" {
+  offering_id    = data.aws_rds_reserved_instance_offering.example.offering_id
+  instance_count = 1
+}
+
+resource "aws_db_instance" "example" {
+  instance_class = aws_rds_reserved_instance.example.db_instance_class
+  tags           = aws_rds_reserved_instance.example.tags.Name
+}

--- a/tests/terraform/for-each-module-output-nested/child/main.tf
+++ b/tests/terraform/for-each-module-output-nested/child/main.tf
@@ -1,0 +1,8 @@
+variable "keys" {}
+
+resource "google_storage_bucket" "x" {
+  for_each = var.keys
+  name     = "static-name-${each.key}"
+  location = "US"
+  labels   = each.value.labels
+}

--- a/tests/terraform/for-each-module-output-nested/labels/main.tf
+++ b/tests/terraform/for-each-module-output-nested/labels/main.tf
@@ -1,0 +1,10 @@
+variable "name" {
+  type = string
+}
+
+output "out" {
+  value = {
+    name   = var.name
+    static = "x"
+  }
+}

--- a/tests/terraform/for-each-module-output-nested/main.tf
+++ b/tests/terraform/for-each-module-output-nested/main.tf
@@ -1,0 +1,19 @@
+variable "names" {
+  default = ["a"]
+}
+
+module "labels" {
+  for_each = toset(var.names)
+  source   = "./labels"
+  name     = each.key
+}
+
+module "child" {
+  for_each = toset(var.names)
+  source   = "./child"
+  keys = {
+    storage = {
+      labels = module.labels[each.key].out
+    }
+  }
+}

--- a/tests/terraform/for-each-module-output/labels/main.tf
+++ b/tests/terraform/for-each-module-output/labels/main.tf
@@ -1,0 +1,3 @@
+variable "name" {
+  type = string
+}

--- a/tests/terraform/for-each-module-output/labels/outputs.tf
+++ b/tests/terraform/for-each-module-output/labels/outputs.tf
@@ -1,0 +1,6 @@
+output "out" {
+  value = {
+    name   = var.name
+    static = "x"
+  }
+}

--- a/tests/terraform/for-each-module-output/main.tf
+++ b/tests/terraform/for-each-module-output/main.tf
@@ -1,0 +1,19 @@
+module "labels" {
+  source = "./labels"
+  name   = "a"
+}
+
+locals {
+  keys = {
+    storage = {
+      labels = module.labels.out
+    }
+  }
+}
+
+resource "google_storage_bucket" "x" {
+  for_each = local.keys
+  name     = "static-name-${each.key}"
+  location = "US"
+  labels   = each.value.labels
+}

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -488,6 +488,40 @@ def test_references(tmp_path):
     ]
 
 
+def test_data_references(tmp_path):
+    """Resource blocks record their references to data blocks.
+
+    Reference paths used to keep the trailing attribute name, so
+    `data.x.example.offering_id` never matched the `data.x.example` block it
+    points at. Resource references were unaffected only because their block
+    type is left out of the path. See #277.
+    """
+    mod_path = init_module("data-references", tmp_path, run_init=False)
+    parsed = load_from_path(mod_path)
+
+    [offering] = parsed["aws_rds_reserved_instance_offering"]
+    [reserved] = parsed["aws_rds_reserved_instance"]
+    [instance] = parsed["aws_db_instance"]
+
+    # resource -> data
+    assert reserved["__tfmeta"]["references"] == [
+        {
+            "id": offering["id"],
+            "label": "aws_rds_reserved_instance_offering",
+            "name": "example",
+        },
+    ]
+
+    # resource -> resource, including a nested attribute reference
+    assert instance["__tfmeta"]["references"] == [
+        {
+            "id": reserved["id"],
+            "label": "aws_rds_reserved_instance",
+            "name": "example",
+        },
+    ]
+
+
 def test_module_references(tmp_path):
     mod_path = init_module("module-references", tmp_path)
     parsed = load_from_path(mod_path)

--- a/tests/test_tfparse.py
+++ b/tests/test_tfparse.py
@@ -744,6 +744,48 @@ def test_not_wholly_known_foreach(tmp_path):
     assert parsed["terraform_data"][0]["for_each"] is None
 
 
+def test_for_each_over_module_output(tmp_path):
+    """A for_each collection holding a module output still expands.
+
+    Module outputs only resolve once submodules have been evaluated, which
+    happens after the expansion rounds -- so the resource used to be left
+    unexpanded with each.key/each.value unbound. See #283.
+    """
+    mod_path = init_module("for-each-module-output", tmp_path, run_init=False)
+    parsed = load_from_path(mod_path)
+
+    buckets = parsed["google_storage_bucket"]
+    assert len(buckets) == 1
+    bucket = buckets[0]
+
+    assert bucket["__tfmeta"]["path"] == 'google_storage_bucket.x["storage"]'
+    assert bucket["name"] == "static-name-storage"
+    assert bucket["labels"] == {"name": "a", "static": "x"}
+
+
+def test_for_each_over_module_output_across_modules(tmp_path):
+    """The same deref works when for_each and the module output cross modules.
+
+    Here the collection reaches the resource as a module input, and the
+    submodule holding the resource is evaluated before the one producing the
+    output -- so the expanded instance also has to pick up the resolved
+    each.value on a later pass. See #283.
+    """
+    mod_path = init_module("for-each-module-output-nested", tmp_path, run_init=False)
+    parsed = load_from_path(mod_path)
+
+    buckets = parsed["google_storage_bucket"]
+    assert len(buckets) == 1
+    bucket = buckets[0]
+
+    assert (
+        bucket["__tfmeta"]["path"]
+        == 'module.child["a"].google_storage_bucket.x["storage"]'
+    )
+    assert bucket["name"] == "static-name-storage"
+    assert bucket["labels"] == {"name": "a", "static": "x"}
+
+
 def test_module_output_json_string(tmp_path):
     """
     Test that module outputs that should be JSON strings are handled correctly.


### PR DESCRIPTION
Address 2 cases where we weren't properly tracking or resolving references:

1. Module references when combined with `for_each` (see #283)
    - This depends on a trivy change (cloud-custodian/trivy#22) - I've updated the trivy pin here to incorporate that change
3. References to `data` attributes (see #277)

Ideally we'll land cloud-custodian/trivy#22 before merging this.

Closes #277 
Closes #283